### PR TITLE
Windows compatibility

### DIFF
--- a/addons/rust_tools/subprocess.gd
+++ b/addons/rust_tools/subprocess.gd
@@ -35,6 +35,8 @@ func set_working_dir(working_dir: String) -> void:
 ## Returns [code]true[/code] if successful.
 func run_sync() -> bool:
 	var command_line := _shell_command_with_chdir()
+	if command_line.is_empty():
+		return false
 	var output := []
 	var read_stderr := true
 	var open_console := false
@@ -49,6 +51,8 @@ func run_sync() -> bool:
 ## Returns [code]true[/code] if started successfully.
 func run_async() -> bool:
 	var command_line := _shell_command_with_chdir()
+	if command_line.is_empty():
+		return false
 	var blocking := true
 	var dict := OS.execute_with_pipe(command_line.path, command_line.arguments, blocking)
 	if dict.is_empty():

--- a/addons/rust_tools/subprocess.gd
+++ b/addons/rust_tools/subprocess.gd
@@ -116,6 +116,9 @@ func _notification(what: int) -> void:
 		# one that'll clean up (wait on) the helper threads.
 		pass
 
+## Constructs the shell command [code]Dictionary[/code] with changing directory,
+## accounting for the OS. If it couldn't be constructed, returns an empty
+## [code]Dictionary[/code].
 func _shell_command_with_chdir() -> Dictionary:
 	# Spawn a shell to change directory first, because Godot's process API does not support that.
 	# Using cargo's `--manifest-path` makes it ignore `.cargo/config.toml`, so that's not an option.

--- a/addons/rust_tools/subprocess.gd
+++ b/addons/rust_tools/subprocess.gd
@@ -86,7 +86,7 @@ func _poll_process(pid: int) -> void:
 	var exit_code := OS.get_process_exit_code(pid)
 	var success := exit_code == 0
 	# Use call_deferred to make sure that signal handlers run on the main thread.
-	call_deferred("_process_finished", success)
+	_process_finished.call_deferred(success)
 
 ## Called on the main thread once the process is finished.
 func _process_finished(success: bool) -> void:


### PR DESCRIPTION
fixes #3 

Added the current compatibility status, implemented a working cmd.exe call, checked for invalid working directories and improved three things on subprocess.gd. I am not sure if the change on the deferred call is an improvement but it removes the need to use strings, which makes it safer overall.