### PR TITLE
Make git autodetect text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
The comment in .gitattributes said it does, but that was wrong: simply "text" instead of "text=auto" makes git treat _every_ file as text, including the PNGs in our repository.