### PR TITLE
Bugfix – fix wrong layer values in constants generator.

### DIFF
--- a/addons/rust_tools/constants_generator.gd
+++ b/addons/rust_tools/constants_generator.gd
@@ -206,7 +206,7 @@ static func _make_named_layer_constant_decl(named_layer: NamedLayer) -> String:
 	return "    pub const {formatted_name}: u32 = {value};\n".format(
 		{
 			formatted_name = _make_const_name(named_layer.name),
-			value = str(named_layer.layer.to_int() - 1)
+			value = str(named_layer.layer.to_int())
 		}
 	)
 


### PR DESCRIPTION
Silly leftover, silly bug.

long story short, instead of generating:

```rs

pub mod physics_3d_layers {
    pub const LAYER_1: u32 = 1;
    pub const LAYER_2: u32 = 2;
    pub const LAYER_3: u32 = 3;
}
```

we were generating
```rs
pub mod physics_3d_layers {
    pub const LAYER_1: u32 = 0;
    pub const LAYER_2: u32 = 1;
    pub const LAYER_3: u32 = 2;
}
```